### PR TITLE
Fix record update attempt with invalid IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,19 @@ Do not include the base domain name in your `subdomains` config. Do not use the 
 }
 ```
 
-### 🗣️ Call to action: Docker environment variable support
+### Docker environment variable support
 
-I am looking for help adding Docker environment variable support to this project. If interested, check out [this comment](https://github.com/timothymiller/cloudflare-ddns/pull/35#issuecomment-974752476) and open a PR.
+Define environmental variables starts with `CF_DDNS_` and use it in config.json
+
+For ex:
+
+```json
+{
+  "cloudflare": [
+    {
+      "authentication": {
+        "api_token": "${CF_DDNS_API_TOKEN}",
+```
 
 ## 🐳 Deploy with Docker Compose
 

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -8,6 +8,8 @@
 
 __version__ = "1.0.2"
 
+from string import Template
+
 import json
 import os
 import signal
@@ -17,7 +19,8 @@ import time
 import requests
 
 CONFIG_PATH = os.environ.get('CONFIG_PATH', os.getcwd())
-
+# Read in all environment variables that have the correct prefix
+ENV_VARS = {key: value for (key, value) in os.environ.items() if key.startswith('CF_DDNS_')}
 
 class GracefulExit:
     def __init__(self):
@@ -216,7 +219,7 @@ if __name__ == '__main__':
     config = None
     try:
         with open(os.path.join(CONFIG_PATH, "config.json")) as config_file:
-            config = json.loads(config_file.read())
+            config = json.loads(Template(config_file.read()).safe_substitute(ENV_VARS))
     except:
         print("😡 Error reading config.json")
         # wait 10 seconds to prevent excessive logging on docker auto restart

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -263,7 +263,10 @@ if __name__ == '__main__':
     config = None
     try:
         with open(os.path.join(CONFIG_PATH, "config.json")) as config_file:
-            config = json.loads(Template(config_file.read()).safe_substitute(ENV_VARS))
+            if len(ENV_VARS) != 0:
+                config = json.loads(Template(config_file.read()).safe_substitute(ENV_VARS))
+            else:
+                config = json.loads(config_file.read())
     except:
         print("😡 Error reading config.json")
         # wait 10 seconds to prevent excessive logging on docker auto restart

--- a/scripts/docker-build-all.sh
+++ b/scripts/docker-build-all.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-docker buildx build --platform  linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ../
+BASH_DIR=$(dirname $(realpath "${BASH_SOURCE}"))
+docker buildx build --platform  linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ${BASH_DIR}/../
 # TODO: Support linux/riscv64

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker build --platform linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ../
+BASH_DIR=$(dirname $(realpath "${BASH_SOURCE}"))
+docker build --platform linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ${BASH_DIR}/../

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker buildx build --platform linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest --push ../
+BASH_DIR=$(dirname $(realpath "${BASH_SOURCE}"))
+docker buildx build --platform linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest --push ${BASH_DIR}/../


### PR DESCRIPTION
> # Issues addressed
> * [https://1.1.1.1/cdn-cgi/trace is down and script tries to update the records with HTML code of the error page #202](https://github.com/timothymiller/cloudflare-ddns/issues/202)
> 
> # Changes
> This PR is a two-parter:
> 
> ## Part 1
> * This is a safe change and non-disruptive in the sense that it does not change any existing behaviour other than the fact that it ensures when the endpoint that is being used to determine the public IPv4/6 address is unavailable or not returning the intended address correctly, it fails instead of returning the error response as the supposed IP address (which causes unwanted, repetitive attempts to update DNS records with this error response).
> * It fixes the linked issue only partially - it fixes the unintended attempts of updating the DNS records with error response values it thought was the IPv4/6 address, but it still is affected by downtimes or currently broken (primary/fallback) Cloudflare endpoints (`https://1.1.1.1/cdn-cgi/trace` and `https://1.0.0.1/cdn-cgi/trace`).
> * Commits: [f0d9510...cbb5ead](https://github.com/timothymiller/cloudflare-ddns/compare/f0d9510fffb026012b68b27b2d35ab742b255696...cbb5ead02f97479538228de85ea042eb357cabcc)
> * Test image: [ghcr.io/irfanhakim-as/cloudflare-ddns:1.0.2-fix-wrong-ip-r1](https://github.com/irfanhakim-as/cloudflare-ddns/pkgs/container/cloudflare-ddns/312084285?tag=1.0.2-fix-wrong-ip-r1)
> 
> ## Part 2
> * Includes Part 1, is safe, but adds a few more modifications that changes an existing behaviour slightly.
> * It fixes the linked issue completely - by adding support for acquiring IPv4/6 address from single-value endpoints (i.e. `https://ipv6.icanhazip.com`) in addition to key-value endpoints as before (i.e. `https://[2606:4700:4700::1111]/cdn-cgi/trace`).
> * This includes adding 2 new global variables (`ipv4_endpoints` and `ipv6_endpoints`), which are used to specify the primary and fallback endpoints for both IP types. These global variables could potentially be used as new config options (by supplying 2-item list of primary and fallback endpoints for each IP type) in the future.
> * The previous default fallback endpoints were updated from `https://1.0.0.1/cdn-cgi/trace` and `https://[2606:4700:4700::1001]/cdn-cgi/trace` to `https://ipv4.icanhazip.com` and `https://ipv6.icanhazip.com` respectively.
> * Commits: [f0d9510...cbb5ead](https://github.com/timothymiller/cloudflare-ddns/compare/f0d9510fffb026012b68b27b2d35ab742b255696...cbb5ead02f97479538228de85ea042eb357cabcc) and [cbb5ead...ba37a97](https://github.com/timothymiller/cloudflare-ddns/compare/cbb5ead02f97479538228de85ea042eb357cabcc...ba37a97d5008d457e625e511b6c7c763ec20d2e2)
> * Test image: [ghcr.io/irfanhakim-as/cloudflare-ddns:1.0.2-fix-wrong-ip-r2](https://github.com/irfanhakim-as/cloudflare-ddns/pkgs/container/cloudflare-ddns/312143281?tag=1.0.2-fix-wrong-ip-r2)
> 
> # Notes
> * I'm not sure about the "usual" or "proper" way of contributing to this repo, i.e. if I need to update the version number in the main script, but feel free to let me know if there's anything I can do to _smoothen_ this PR in case you intend to merge it!
> * My test images were only built for `linux/amd64` for simplicity - if you are testing this on a different platform, please try the following image instead which I have built for all 7 platforms the official image supports: [ghcr.io/irfanhakim-as/cloudflare-ddns:1.0.2-fix-wrong-ip-r3](https://github.com/irfanhakim-as/cloudflare-ddns/pkgs/container/cloudflare-ddns/347894678?tag=1.0.2-fix-wrong-ip-r3)

https://github.com/timothymiller/cloudflare-ddns/pull/203#issuecomment-2629796356